### PR TITLE
ログ出力方法を修正 console -> context

### DIFF
--- a/deployPrj01/LineHttpTriggeredFunction/index.js
+++ b/deployPrj01/LineHttpTriggeredFunction/index.js
@@ -47,16 +47,16 @@ const app = express();
 // about the middleware, please refer to doc
 app.post('/api/linehttptriggeredfunction', line.middleware(config), (req, res) => {
   Promise
-    .all(req.body.events.map(handleEvent))
+    .all(req.body.events.map(e => handleEvent(e, req.context)))
     .then((result) => res.json(result))
     .catch((err) => {
-      console.error(err);
+      req.context.log.error(err);
       res.status(500).end();
     });
 });
 
 // event handler
-async function handleEvent(event) {
+async function handleEvent(event, context) {
   const userId = event.source.userId;
   if (event.type !== 'message' && event.type !== 'postback') {
     // ignore non-text-message event


### PR DESCRIPTION
ログ出力方法が誤っていたので修正（引用元の私の記事のミスです、すみません。元記事も修正済み）。

処理本体でもログ出力できるよう `handleEvent` にも `context` を渡しています。

[Azure Functions の JavaScript 開発者向けガイド - context.log メソッド](https://docs.microsoft.com/ja-jp/azure/azure-functions/functions-reference-node?tabs=v2-v3-v4-export%2Cv2-v3-v4-done%2Cv2%2Cv2-log-custom-telemetry%2Cv2-accessing-request-and-response%2Cwindows-setting-the-node-version#contextlog-method)